### PR TITLE
Remove attempt at auto python version discovery

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,11 +8,6 @@ on:
   pull_request:
 
 
-  defaults:
-    run:
-      shell: bash
-
-
 jobs:
 
   lint:
@@ -31,6 +26,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12.0-alpha - 3.12"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"] # Not all python versions are available for all OSes
+    defaults:
+      run:
+        shell: bash
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
Auto python version discovery is difficult with multiple OSes, as not all versions are available for all OSes. This removes my attempt at auto version discovery and reverts to a hardcoded list. 